### PR TITLE
topic/rename contracts & remove pkg depenedencies

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "submodule-protocol"]
+	path = submodule-protocol
+	url = https://github.com/starlay-finance/starlay-protocol

--- a/contracts/proposals/extend-stkaave-distribution/StakedTokenBptV2Rev2.sol
+++ b/contracts/proposals/extend-stkaave-distribution/StakedTokenBptV2Rev2.sol
@@ -1,6 +1,6 @@
 // Sources flattened with hardhat v2.0.8 https://hardhat.org
 
-// File @aave/aave-token/contracts/open-zeppelin/Context.sol@v1.0.4
+// File @pj/pj-token/contracts/open-zeppelin/Context.sol@v1.0.4
 
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.7.5;
@@ -111,7 +111,7 @@ interface IERC20 {
   event Approval(address indexed owner, address indexed spender, uint256 value);
 }
 
-// File @aave/aave-token/contracts/open-zeppelin/ERC20.sol@v1.0.4
+// File @pj/pj-token/contracts/open-zeppelin/ERC20.sol@v1.0.4
 
 /**
  * @dev Implementation of the {IERC20} interface.
@@ -1075,7 +1075,7 @@ interface IERC20Detailed is IERC20 {
   function decimals() external view returns (uint8);
 }
 
-// File @aave/aave-token/contracts/interfaces/IGovernancePowerDelegationToken.sol@v1.0.4
+// File @pj/pj-token/contracts/interfaces/IGovernancePowerDelegationToken.sol@v1.0.4
 
 interface IGovernancePowerDelegationToken {
   enum DelegationType {VOTING_POWER, PROPOSITION_POWER}
@@ -1150,7 +1150,7 @@ interface IGovernancePowerDelegationToken {
   function totalSupplyAt(uint256 blockNumber) external view virtual returns (uint256);
 }
 
-// File @aave/aave-token/contracts/token/base/GovernancePowerDelegationERC20.sol@v1.0.4
+// File @pj/pj-token/contracts/token/base/GovernancePowerDelegationERC20.sol@v1.0.4
 
 /**
  * @notice implementation of the token contract

--- a/contracts/proposals/extend-stkaave-distribution/interfaces/LendingPoolInterfaces.sol
+++ b/contracts/proposals/extend-stkaave-distribution/interfaces/LendingPoolInterfaces.sol
@@ -1,5 +1,4 @@
 import '../../../../submodule-protocol/contracts/interfaces/ILendingPool.sol';
 import '../../../../submodule-protocol/contracts/interfaces/ILendingPoolAddressesProvider.sol';
 import '../../../../submodule-protocol/contracts/dependencies/openzeppelin/contracts/IERC20.sol';
-import '@aave/protocol-v2/contracts/dependencies/openzeppelin/contracts/IERC20.sol';
-import '@aave/protocol-v2/contracts/misc/AaveProtocolDataProvider.sol';
+import '../../../../submodule-protocol/contracts/misc/StarlayProtocolDataProvider.sol';

--- a/contracts/proposals/extend-stkaave-distribution/interfaces/LendingPoolInterfaces.sol
+++ b/contracts/proposals/extend-stkaave-distribution/interfaces/LendingPoolInterfaces.sol
@@ -1,5 +1,5 @@
-import '@aave/protocol-v2/contracts/interfaces/ILendingPool.sol';
-import '@aave/protocol-v2/contracts/interfaces/ILendingPoolAddressesProvider.sol';
-import '@aave/protocol-v2/contracts/dependencies/openzeppelin/contracts/IERC20.sol';
+import '../../../../submodule-protocol/contracts/interfaces/ILendingPool.sol';
+import '../../../../submodule-protocol/contracts/interfaces/ILendingPoolAddressesProvider.sol';
+import '../../../../submodule-protocol/contracts/dependencies/openzeppelin/contracts/IERC20.sol';
 import '@aave/protocol-v2/contracts/dependencies/openzeppelin/contracts/IERC20.sol';
 import '@aave/protocol-v2/contracts/misc/AaveProtocolDataProvider.sol';

--- a/contracts/stake-v1/contracts/token/base/GovernancePowerDelegationERC20.sol
+++ b/contracts/stake-v1/contracts/token/base/GovernancePowerDelegationERC20.sol
@@ -8,8 +8,8 @@ import {
 } from '../../interfaces/IGovernancePowerDelegationToken.sol';
 
 /**
- * @notice implementation of the AAVE token contract
- * @author Aave
+ * @notice implementation of the token contract
+ * @author Starlay
  */
 abstract contract GovernancePowerDelegationERC20 is ERC20, IGovernancePowerDelegationToken {
   using SafeMath for uint256;
@@ -102,8 +102,8 @@ abstract contract GovernancePowerDelegationERC20 is ERC20, IGovernancePowerDeleg
   /**
    * @dev returns the total supply at a certain block number
    * used by the voting strategy contracts to calculate the total votes needed for threshold/quorum
-   * In this initial implementation with no AAVE minting, simply returns the current supply
-   * A snapshots mapping will need to be added in case a mint function is added to the AAVE token in the future
+   * In this initial implementation with no LAY minting, simply returns the current supply
+   * A snapshots mapping will need to be added in case a mint function is added to the LAY token in the future
    **/
   function totalSupplyAt(uint256 blockNumber) external override view returns (uint256) {
     return super.totalSupply();
@@ -247,7 +247,7 @@ abstract contract GovernancePowerDelegationERC20 is ERC20, IGovernancePowerDeleg
   /**
    * @dev returns the delegation data (snapshot, snapshotsCount, list of delegates) by delegation type
    * NOTE: Ideal implementation would have mapped this in a struct by delegation type. Unfortunately,
-   * the AAVE token and StakeToken already include a mapping for the snapshots, so we require contracts
+   * the LAY token and StakeToken already include a mapping for the snapshots, so we require contracts
    * who inherit from this to provide access to the delegation data by overriding this method.
    * @param delegationType the type of delegation
    **/

--- a/contracts/stake-v1/contracts/utils/DoubleTransferHelper.sol
+++ b/contracts/stake-v1/contracts/utils/DoubleTransferHelper.sol
@@ -5,14 +5,14 @@ import "../interfaces/IERC20.sol";
 
 contract DoubleTransferHelper {
 
-    IERC20 public immutable AAVE;
+    IERC20 public immutable TOKEN;
 
-    constructor(IERC20 aave) public {
-        AAVE = aave;
+    constructor(IERC20 token) public {
+        TOKEN = token;
     }
 
     function doubleSend(address to, uint256 amount1, uint256 amount2) external {
-        AAVE.transfer(to, amount1);
-        AAVE.transfer(to, amount2);
+        TOKEN.transfer(to, amount1);
+        TOKEN.transfer(to, amount2);
     }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,15 +4,6 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
-    "@aave/protocol-v2": {
-      "version": "1.0.2-fat.3",
-      "resolved": "https://registry.npmjs.org/@aave/protocol-v2/-/protocol-v2-1.0.2-fat.3.tgz",
-      "integrity": "sha512-G06EN+K8YLAwqfiNS96gQ0y1Q9Kp+G8Lk+tuNGy5br4E1fQ85mAdwLH8wRVTMyDvKYHK0fpRagV6JyEwd6lq+w==",
-      "dev": true,
-      "requires": {
-        "tmp-promise": "^3.0.2"
-      }
-    },
     "@babel/code-frame": {
       "version": "7.12.11",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.11.tgz",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,6 @@
     "prepublishOnly": "npm run compile"
   },
   "devDependencies": {
-    "@aave/protocol-v2": "^1.0.2-fat.3",
     "@nomiclabs/hardhat-ethers": "^2.0.1",
     "@nomiclabs/hardhat-etherscan": "^2.1.0",
     "@nomiclabs/hardhat-waffle": "^2.0.1",

--- a/test-fork/helpers.ts
+++ b/test-fork/helpers.ts
@@ -1,6 +1,6 @@
 import { tEthereumAddress } from '../helpers/types';
 import {
-  AaveProtocolDataProvider__factory,
+  StarlayProtocolDataProvider__factory,
   Erc20__factory,
   ILendingPoolAddressesProvider__factory,
 } from '../types';
@@ -61,7 +61,7 @@ export const getReserveConfigs = async (
     poolProviderAddress,
     proposer
   );
-  const protocolDataProvider = await AaveProtocolDataProvider__factory.connect(
+  const protocolDataProvider = await StarlayProtocolDataProvider__factory.connect(
     await poolProvider.getAddress(
       '0x0100000000000000000000000000000000000000000000000000000000000000'
     ),


### PR DESCRIPTION
remove pkg @aave/protocol-v2

- modify comments
- add starlay-finance/starlay-protocol as submodule (submodule-protocol folder)
- use contracts/interfaces in starlay-protocol instead of @aave/protocol-v2 (except ProtocolDataProvider)
- use StarlayProtocolDataProvider in starlay-protocol instead of @aave/protocol-v2
- uninstall pkg - @aave/protocol-v2
